### PR TITLE
remove ; from the raw line

### DIFF
--- a/require/class.SBS.php
+++ b/require/class.SBS.php
@@ -19,7 +19,12 @@ class SBS {
 		// Not yet finished, no CRC checks
 		$data = array();
 		$typehex = substr($buffer,0,1);
-		if ($typehex == '*' || $typehex == ':') $hex = substr($buffer,1);
+		if ($typehex == '*' || $typehex == ':') {
+			$hex = substr($buffer,1);
+			if(substr($hex,-1,1)==";") {
+				$hex=substr($hex,0,-1);
+			}
+		}
 		//elseif ($typehex == '@' || $typehex == '%') $hex = substr($buffer,13,-13);
 		elseif ($typehex == '@' || $typehex == '%') $hex = substr($buffer,13,-1);
 		else $hex = substr($buffer,1,-1);


### PR DESCRIPTION
when I add a source to use raw port 30002 of piaware,  the suffix ; must be removed.

ex)
pi@piaware:~ $ telnet localhost 30002
Trying ::1...
Connected to localhost.
Escape character is '^]'.
*02A1849BBDB017;
*A8001CB5F038CB23BE8492EADD17;
*02A1869BA1AAA7;
*A000069BB6B00030E000005C68CE;
*8D71BF8699C457A2010C0A0F7091;