### PR TITLE
ident filter: fix and improve usability

### DIFF
--- a/index.php
+++ b/index.php
@@ -834,7 +834,7 @@ require_once('header.php');
 		    ?>
 		    <li>
 			<?php echo _("Display with ident:"); ?>
-			<input type="text" name="identfilter" onchange="identfilter();" id="identfilter" value="<?php if (isset($_COOKIE['filter_ident'])) print $_COOKIE['filter_ident']; ?>" />
+			<input type="text" name="identfilter" onchange="fnidentfilter();" id="identfilter" value="<?php if (isset($_COOKIE['filter_ident'])) print $_COOKIE['filter_ident']; ?>" />
 		    </li>
 		</ul>
 	    </form>
@@ -912,7 +912,7 @@ require_once('header.php');
     $("#identfilter").on('input', function() {
 	clearTimeout(typingTimer);
 	if (this.value) {
-	    typingTimer = setTimeout(identfilter,doneTypingInterval);
+	    typingTimer = setTimeout(fnidentfilter,doneTypingInterval);
 	}
     });
 </script>

--- a/js/map.common.js
+++ b/js/map.common.js
@@ -173,8 +173,8 @@ function alliance(selectObj) {
     var alliance = selectObj.options[idx].value;
     createCookie('filter_alliance',alliance,2);
 }
-function identfilter() {
-    var ident = $("#identfilter").value;
+function fnidentfilter() {
+    var ident = $("#identfilter").val();
     createCookie('filter_ident',ident,2);
 }
 function mmsifilter() {

--- a/require/class.SpotterLive.php
+++ b/require/class.SpotterLive.php
@@ -95,7 +95,7 @@ class SpotterLive {
 			}
 		}
 		if (isset($filter['ident']) && !empty($filter['ident'])) {
-			$filter_query_where .= " AND ident = '".$filter['ident']."'";
+			$filter_query_where .= " AND ident LIKE '".$filter['ident']."%'";
 		}
 		if (isset($filter['id']) && !empty($filter['id'])) {
 			$filter_query_where .= " AND flightaware_id = '".$filter['id']."'";


### PR DESCRIPTION
1. "Display with ident" not working on chrome.   

2. Change exact match(=) to LIKE on mysql. ( ex. to display only korean airline, Just type KAL )  
