### PR TITLE
Update class.Marine.php

### DIFF
--- a/require/class.Marine.php
+++ b/require/class.Marine.php
@@ -333,7 +333,7 @@ class Marine{
 			{
 				return array();
 			} else {
-				$additional_query = " AND marine_output.ident = :ident";
+				$additional_query = " marine_output.ident = :ident";
 				$query_values = array(':ident' => $ident);
 			}
 		}


### PR DESCRIPTION
removed 'AND' at line 336 as this was generating bad SQL, returning this error:

Invalid query : SQLSTATE[42000]: Syntax error or access violation: 1064 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'AND marine_output.ident = 'MARIELLA' ORDER BY marine_output.date DESC LIMIT 25 ' at line 1 Whole query: SELECT marine_output.* FROM marine_output WHERE AND marine_output.ident = :ident ORDER BY marine_output.date DESC LIMIT 25 OFFSET 0